### PR TITLE
build: add the EE related env variable for unit testing

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -10,6 +10,8 @@ on:
 env:
   FORCE_COLOR: 1
   PIP_ROOT_USER_ACTION: ignore
+  EARTHENGINE_TOKEN: ${{ secrets.EARTHENGINE_TOKEN }}
+  EARTHENGINE_PROJECT: ${{ secrets.EARTHENGINE_PROJECT }}
 
 jobs:
   lint:


### PR DESCRIPTION
I followed the installation process from the pytest_gee documentation: https://pytest-gee.readthedocs.io/en/latest/content/installation.html