### PR TITLE
fix: show error message when image cannot get fetched + fix one band …

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,3 +169,9 @@ def s2_image_overlay_styled() -> ee.FeatureCollection:
 def s2_image_viz() -> dict:
     """Sentinel 2 image visualization parameters."""
     return {"bands": ["B8", "B11", "B4"], "min": 0, "max": 4500}
+
+
+@pytest.fixture
+def fail_image() -> ee.Image:
+    """An empty collection to test failure cases."""
+    return ee.ImageCollection.fromImages([ee.Image(1).toInt(), ee.Image(2).toFloat()]).mean()

--- a/tests/test_eeimage.py
+++ b/tests/test_eeimage.py
@@ -1,5 +1,7 @@
 """Test eeimage module."""
 
+import pytest
+
 from geepillow.image import from_eeimage
 
 
@@ -57,3 +59,8 @@ class TestImage:
         )
 
         pil_image_regression.check(image)
+
+    def test_from_eeimage_fail(self, fail_image, s2_image_overlay):
+        """Test eeimage module with invalid parameters."""
+        with pytest.raises(RuntimeError):
+            from_eeimage(fail_image, dimensions=500, region=s2_image_overlay)


### PR DESCRIPTION
When the image cannot be fetched, the URL contains the error message. Now it catches the error and raise a `RuntimeError` when this happens showing the correct error message.

While fixing this I realized that it was not prepared for one-band images, so I also fixed it.